### PR TITLE
Hardcode git URL in metadata to prevent other users from overwriting

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -26,6 +26,12 @@
       }
     ],
     "dest": "docs",
+    "globalMetadata": {
+      "_gitContribute": {
+        "repo": "https://github.com/billti/jsdocs",
+        "branch": "master"
+      }
+    },
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],
     "template": [


### PR DESCRIPTION
FYI @billti 