### PR TITLE
Increase allowed file size for ETW instructions

### DIFF
--- a/articles/troubleshooting/index.md
+++ b/articles/troubleshooting/index.md
@@ -235,7 +235,7 @@ with Administrative rights, and run the following commands:
 
 1. `SET VSEXE=%VSINSTALLDIR%Common7\IDE\devenv.exe`
 2. `SET ETWPROV=*TypeScriptEventSource,*Microsoft-VisualStudio-Common`
-3. `PerfView -KernelEvents:FileIOInit,ThreadTime -Providers:%ETWPROV% run "%VSEXE%"`
+3. `PerfView -KernelEvents:FileIOInit,ThreadTime -Providers:%ETWPROV% -CircularMB:4096 -BufferSizeMB:256 run "%VSEXE%"`
 
 Visual Studio should launch. Reproduce the issue, then stop the PerfView trace. The zip file created
 contains detailed logging of file access, asynchronous tasks, Visual Studio internal events, and events


### PR DESCRIPTION
When asking users to provide ETW traces, they frequently run out of room before valuable events are captured. The CircularMB flag ensures we capture the last 4 gigs of data, rather than giving up when the max file size is hit. These flags are taken from the suggested switches at https://github.com/dotnet/roslyn/wiki/Recording-performance-traces-with-PerfView